### PR TITLE
Feature/print

### DIFF
--- a/mrobpy/SE3py.cpp
+++ b/mrobpy/SE3py.cpp
@@ -133,6 +133,9 @@ void init_geometry(py::module &m) {
         .def("distance", &SO3::distance,
                 "Calculates the distance between rotation matrices as ||Ln(R'*R_i)||")
         .def("print", &SO3::print, "Prints current information of the rotation")
+        .def("__mul__", &SO3::operator*, py::is_operator())
+        .def("__str__", &SO3::toString, "Generates string representation of the SO3 object for print() output")
+        .def("__repr__", &SO3::toString, "Generates string representation of the SO3 object for console output");
         ;
     m.def("isSO3", &mrob::isSO3, "Returns True is the matrix is a valid rotation and False if not");
 
@@ -176,7 +179,9 @@ void init_geometry(py::module &m) {
                  py::overload_cast<const SE3Cov &>(&SE3Cov::mul, py::const_),
                  "Multiplication method mul() as an interface for compounding.",
                  py::return_value_policy::copy)
-            .def("__mul__", &SE3Cov::operator*, py::is_operator());
+            .def("__mul__", &SE3Cov::operator*, py::is_operator())
+            .def("__str__", &SE3Cov::toString, "Generates string representation of the SE3cov object for print() output")
+            .def("__repr__", &SE3Cov::toString, "Generates string representation of the SE3cov object for console output");
         m.def("curley_wedge", &mrob::curly_wedge, "Returns 6-by-6 matrix, the output of curley wedge operator.", py::return_value_policy::copy);
 }
 

--- a/mrobpy/SE3py.cpp
+++ b/mrobpy/SE3py.cpp
@@ -98,7 +98,9 @@ void init_geometry(py::module &m) {
                 "Calculates the translation distance. If no element is provided this is just the element norm",
                 py::arg("rhs")=SE3())
         .def("print", &SE3::print, "Prints the current SE3 element")
-        .def("__mul__", &SE3::operator*, py::is_operator());
+        .def("__mul__", &SE3::operator*, py::is_operator())
+        .def("__str__", &SE3::toString, "Generates string representation of the SE3 object for print() output")
+        .def("__repr__", &SE3::toString, "Generates string representation of the SE3 object for console output");
 ;
     m.def("isSE3", &mrob::isSE3, "Returns True is the matrix is a valid transformation and False if not");
 

--- a/python_examples/SE3_examples.py
+++ b/python_examples/SE3_examples.py
@@ -38,7 +38,7 @@ if 1:
     print('Printing orientations')
     w = np.zeros(3)
     R = mrob.geometry.SO3(w)
-    R.print()
+    print(R)
     ax = plotConfig()
     T = np.eye(4)
     T[:3,:3] = R.R()
@@ -51,7 +51,7 @@ if 1:
     # Rotation on z axis
     w[2] = -np.pi/4
     R = mrob.geometry.SO3(w)
-    R.print()
+    print(R)
     T[:3,:3] = R.R()
     ax = plotConfig()
     plotT(mrob.geometry.SE3(T),ax)
@@ -64,7 +64,7 @@ if 1:
     # Rotation on z axis
     w = np.random.randn(3)
     R = mrob.geometry.SO3(w)
-    R.print()
+    print(R)
     T[:3,:3] = R.R()
     ax = plotConfig()
     plotT(mrob.geometry.SE3(T),ax)
@@ -95,22 +95,22 @@ if 1:
     T_0 = mrob.geometry.SE3(xi_ini)
     T_0_inv = T_0.inv()
     T_1 = mrob.geometry.SE3(xi_fin)
-    T_1.print()
-    print('direct T1\n',T_1.T())
-    mrob.geometry.SE3(T_1.T()).print()
+    print(T_1)
+    print('direct T1\n',T_1)
+    print(mrob.geometry.SE3(T_1.T()))
     #dxi = mrob.geometry.SE3( (T_1.T() @ T_0_inv.T()) ).Ln()
-    dxi = T_1.mul(T_0_inv).Ln()
+    dxi = (T_1*T_0_inv).Ln()
     for i in range(N):
         Ti = mrob.geometry.SE3(xi[i,:])
         plotT(Ti,ax)
-        #print(Ti.T())
+        #print(Ti)
         
-        Ts = mrob.geometry.SE3(t[i]*dxi).mul(T_0)
-        #print(Ts.T())
+        Ts = mrob.geometry.SE3(t[i]*dxi)*T_0
+        #print(Ts)
         plotT(Ts,ax)
         
         # ploting and visualizing error
-        #print(Ts.T())
+        #print(Ts)
         print(np.linalg.norm(Ti.Ln() - Ts.Ln()))
         #T.transform(np.array([0,0,0], dtype='float64'))
     plt.show()
@@ -131,6 +131,6 @@ if 0:
 if 0:
     w = np.random.rand(3)
     R = mrob.geometry.SO3(w)
-    print('SO3 matrix: \n', R.R() )
+    print('SO3 matrix: \n', R )
     print('SO3 in the manifold: \n', R.Ln())
     

--- a/src/geometry/SE3.cpp
+++ b/src/geometry/SE3.cpp
@@ -340,11 +340,9 @@ Mat4 mrob::SE3GenerativeMatrix(uint_t coordinate)
     return G;
 }
 
-
-
-
-
-
-
-
-
+std::string SE3::toString() const
+{
+    std::stringstream ss;
+    ss << this->T_;
+    return ss.str();
+}

--- a/src/geometry/SE3cov.cpp
+++ b/src/geometry/SE3cov.cpp
@@ -136,7 +136,14 @@ SE3Cov SE3Cov::operator*(const SE3Cov& rhs) const
     return SE3Cov::compound_2nd_order(rhs);
 }
 
-Mat6 mrob::curly_wedge(const Mat61& xi)
+std::string mrob::SE3Cov::toString() const
+{
+    std::stringstream ss;
+    ss << this->T_;
+    return ss.str();
+}
+
+Mat6 mrob::curly_wedge(const Mat61 &xi)
 {
     Mat6 result(Mat6::Zero());
     result.topLeftCorner<3,3>() = mrob::hat3(xi.head(3));

--- a/src/geometry/SO3.cpp
+++ b/src/geometry/SO3.cpp
@@ -87,6 +87,13 @@ void SO3::update_rhs(const Mat31 &dw)
     R_ = R_ * dR.R();
 }
 
+std::string SO3::toString() const
+{
+    std::stringstream ss;
+    ss << this->R_;
+    return ss.str();
+}
+
 Mat31 mrob::vee3(const Mat3 &w_hat)
 {
     Mat31 w;

--- a/src/geometry/mrob/SE3.hpp
+++ b/src/geometry/mrob/SE3.hpp
@@ -189,6 +189,13 @@ public:
     void print(void) const;
     void print_lie(void) const;
 
+    /**
+     * @brief Generates string representation of the object
+     *
+     * @return std::string object to print
+     */
+    std::string toString() const;
+
 protected:
     Mat4 T_;
 

--- a/src/geometry/mrob/SE3cov.hpp
+++ b/src/geometry/mrob/SE3cov.hpp
@@ -110,6 +110,14 @@ namespace mrob
          * **/
         SE3Cov operator*(const SE3Cov &rhs) const;
 
+
+        /**
+         * @brief Generates string representation of the SE3cov object
+         *
+         * @return std::string object to print
+         */
+        std::string toString() const;
+
     protected:
         /**
          * @brief This is the 6x6 covariance matrix of the current pose.

--- a/src/geometry/mrob/SO3.hpp
+++ b/src/geometry/mrob/SO3.hpp
@@ -138,6 +138,14 @@ public:
     void print_lie(void) const;
 
 
+    /**
+     * @brief Generates string representation of the SO3 object
+     *
+     * @return std::string object to print
+     */
+    std::string toString() const;
+
+
 protected:
     Mat3 R_;
 


### PR DESCRIPTION
- defined built-in methods `__str__` and `__repr__` to be able to have string representations of objects `SO3`, `SE3`, `SE3cov` when calling `print(T)` or just typing variable in python terminal. In the C++ backend it's `toString() const` method.
- added `operator*` for SO3;
- updated the `SE3_examples.py` script

Had to have `toString` redifined for all three classes, because we don't have any inheritance here.