### PR TITLE
CI fix

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-11, windows-2019]
+        os: [ubuntu-latest, macos-12, windows-2019]
     steps:
       - uses: actions/checkout@v3
 

--- a/external/pybind11/CMakeLists.txt
+++ b/external/pybind11/CMakeLists.txt
@@ -3,7 +3,6 @@ include(FetchContent)
 FetchContent_Declare(
     pybind11
     GIT_REPOSITORY https://github.com/pybind/pybind11.git
-    GIT_TAG v2.10.1
+    GIT_TAG v2.13.5
 )
-
 FetchContent_MakeAvailable(pybind11)

--- a/mrobpy/setup.cfg
+++ b/mrobpy/setup.cfg
@@ -29,7 +29,7 @@ license = Apache-2.0
 license_files = LICENSE.md
 
 [options]
-python_requires = >= 3.6
+python_requires = >= 3.7
 
 [options.package_data]
 * = 


### PR DESCRIPTION
* Migrated to fresh pybind to have compatibilty with numpy 2.0
* Migrate to macos-12 (macos-11 is no longer supported)
* Removed python 3.6 (no longer supported)