### PR TITLE
updating to version pybind11 v3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,9 @@ ENDIF(ANDROID)
 #####################################
 # External dependencies
 #####################################
+#set(PYBIND11_FINDPYTHON ON)
+#set(PYBIND11_FINDPYTHON ON CACHE BOOL "" FORCE)
+set(PYBIND11_FINDPYTHON NEW)
 add_subdirectory(external)
 
 #####################################

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -4,6 +4,8 @@ if (BUILD_TESTING)
     add_subdirectory(Catch2)
 endif()
 
+
+set(PYBIND11_FINDPYTHON NEW)
 if (NOT ANDROID)
     add_subdirectory(pybind11)
 endif()

--- a/external/pybind11/CMakeLists.txt
+++ b/external/pybind11/CMakeLists.txt
@@ -3,6 +3,6 @@ include(FetchContent)
 FetchContent_Declare(
     pybind11
     GIT_REPOSITORY https://github.com/pybind/pybind11.git
-    GIT_TAG v2.13.5
+    GIT_TAG v3.0.4
 )
 FetchContent_MakeAvailable(pybind11)

--- a/python_examples/FGraph_M3500.py
+++ b/python_examples/FGraph_M3500.py
@@ -104,10 +104,11 @@ print('solution drawn')
 print_2d_graph(graph)
 
 
-if 0:
+if 1:
     # Information matrix
     import matplotlib.pyplot as plt
-    L = graph.get_information_matrix()
+    #L = graph.get_information_matrix()
+    L = graph.get_adjacency_matrix()
     plt.spy(L, marker='o', markersize=5)
     plt.title('Information matrix $\Lambda$')
     plt.show()
@@ -119,7 +120,7 @@ if 0:
 
 # alternative use Gauss-Newton
 if 0:
-    graph.solve(mrob.fgraph.GN)
+    graph.solve(mrob.GN)
     print('Iter 0 chi2 = ', graph.chi2() )
     graph.solve(mrob.GN)
     print('Iter 1 chi2 = ', graph.chi2() )

--- a/python_examples/PC_align.py
+++ b/python_examples/PC_align.py
@@ -10,6 +10,8 @@ X =  np.random.rand(N,3)
 T = mrob.geometry.SE3(np.random.rand(6))
 Y = T.transform_array(X)
 
+Y += np.random.randn(N,3)*0.01
+
 print('X = \n', X,'\n T = \n', T.T(),'\n Y =\n', Y)
 
 

--- a/src/pybind/CMakeLists.txt
+++ b/src/pybind/CMakeLists.txt
@@ -1,5 +1,8 @@
 if (NOT PYTHON_EXECUTABLE)
-    message(FATAL_ERROR "PYTHON_EXECUTABLE was not found in top level file")
+    # Bridge the internal/modern path to the legacy uppercase variable your submodule expects
+    set(PYTHON_EXECUTABLE "/usr/bin/python3.8" CACHE FILEPATH "Bridge for submodule" FORCE)
+    message("PYTHON_EXECUTABLE not found, added manually CAREFUL HERE")
+    #message(FATAL_ERROR "PYTHON_EXECUTABLE was not found in top level file")
 endif ()
 
 pybind11_add_module(pybind)

--- a/src/pybind/FGraphPy.cpp
+++ b/src/pybind/FGraphPy.cpp
@@ -24,6 +24,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/eigen.h>
 #include <pybind11/stl.h>
+#include <pybind11/native_enum.h>
 
 
 #include "mrob/factor_graph_solve.hpp"
@@ -354,25 +355,32 @@ private:
 
 void init_FGraph(py::module &m)
 {
-    py::enum_<FGraphSolve::optimMethod>(m, "FGraph.optimMethod")
+    py::native_enum<FGraphSolve::optimMethod>(m, 
+                        "FGraph.optimMethod",
+                        "enum.Enum")
         .value("GN", FGraphSolve::optimMethod::GN)
         .value("LM", FGraphSolve::optimMethod::LM)
         .value("LM_ELLIPS", FGraphSolve::optimMethod::LM_ELLIPS)
         .export_values()
+        .finalize()
         ;
-    py::enum_<Factor::robustFactorType>(m, "FGraph.robustFactorType")
+    py::native_enum<Factor::robustFactorType>(m, 
+                    "FGraph.robustFactorType",
+                    "enum.Enum")
         .value("QUADRATIC", Factor::robustFactorType::QUADRATIC)
         .value("CAUCHY", Factor::robustFactorType::CAUCHY)
         .value("HUBER", Factor::robustFactorType::HUBER)
         .value("MCCLURE", Factor::robustFactorType::MCCLURE)
         .value("RANSAC", Factor::robustFactorType::RANSAC)
         .export_values()
+        .finalize()
         ;
-    py::enum_<Node::nodeMode>(m, "FGraph.nodeMode")
+    py::native_enum<Node::nodeMode>(m, "FGraph.nodeMode", "enum.Enum")
     .value("NODE_STANDARD", Node::nodeMode::STANDARD)
     .value("NODE_ANCHOR", Node::nodeMode::ANCHOR)
     .value("NODE_SCHUR_MARGI", Node::nodeMode::SCHUR_MARGI)
     .export_values()
+    .finalize()
     ;
     // Fgraph class adding factors and providing method to solve the inference problem.
     py::class_<FGraphPy> (m,"FGraph")

--- a/src/pybind/PCPlanesPy.cpp
+++ b/src/pybind/PCPlanesPy.cpp
@@ -30,6 +30,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/eigen.h>
 #include <pybind11/stl.h>
+#include <pybind11/native_enum.h>
 namespace py = pybind11;
 
 #include "mrob/plane.hpp"
@@ -62,7 +63,8 @@ Mat4 estimate_matrix_S(const py::EigenDRef<const MatX> pointsArray)
 
 void init_PCPlanes(py::module &m)
 {
-    py::enum_<PlaneRegistration::SolveMode>(m, "PlaneRegistration.SolveMethod")
+    py::native_enum<PlaneRegistration::SolveMode>(m, 
+                        "PlaneRegistration.SolveMethod", "enum.Enum")
         .value("INITIALIZE", PlaneRegistration::SolveMode::INITIALIZE)
         .value("GRADIENT_BENGIOS_NAG", PlaneRegistration::SolveMode::GRADIENT_BENGIOS_NAG)
         .value("GRADIENT_ALL_POSES", PlaneRegistration::SolveMode::GRADIENT_ALL_POSES)
@@ -71,6 +73,7 @@ void init_PCPlanes(py::module &m)
         .value("LM_SPHER", PlaneRegistration::SolveMode::LM_SPHER)
         .value("LM_ELLIP", PlaneRegistration::SolveMode::LM_ELLIP)
         .export_values()
+        .finalize()
         ;
     // This class creates a synthetic testing
     py::class_<CreatePoints>(m,"CreatePoints")

--- a/src/pybind/mrobPy.cpp
+++ b/src/pybind/mrobPy.cpp
@@ -24,6 +24,7 @@
 
 #include <pybind11/pybind11.h>
 #include <pybind11/iostream.h>
+#include <pybind11/native_enum.h>
 
 
 #include "mrob/optimizer.hpp"
@@ -47,11 +48,12 @@ PYBIND11_MODULE(pybind, m) {
     py::add_ostream_redirect(m, "ostream_redirect");
 
     //TODO: deprecated. this enum are no longer used?
-    py::enum_<mrob::Optimizer::optimMethod>(m, "optimMethod")
+    py::native_enum<mrob::Optimizer::optimMethod>(m, "optimMethod", "enum.Enum")
         .value("NEWTON_RAPHSON", mrob::Optimizer::optimMethod::NEWTON_RAPHSON)
         .value("LEVENBERG_MARQUARDT_SPHER", mrob::Optimizer::optimMethod::LEVENBERG_MARQUARDT_SPHER)
         .value("LEVENBERG_MARQUARDT_ELLIP", mrob::Optimizer::optimMethod::LEVENBERG_MARQUARDT_ELLIP)
         .export_values()
+        .finalize()
         ;
 
     // TODO to be deprecated this namespace


### PR DESCRIPTION
Current fix does its job, but locally.

It requires to find a way to import PYTHON_EXECUTABLE in a cleaner way (see pybind/CMake). 
This is a problem with newer pybind11, not exposing PYTHON_EXECUTABLE and making it _Python_EXECUTABLE (as in CMake log). 

In wheels we specify the PYTHON_EXECUTABLE

Check and TEST in different python envs with different numpy versions